### PR TITLE
Fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn add react-optimize
 You first need to add the gtag snippet with the optimize container id in it. If you are using [create-react-app](https://github.com/facebook/create-react-app)
 you can add the following to `public/index.html`
 
-```
+```html
 <script async src="https://www.googletagmanager.com/gtag/js?id=%REACT_APP_GA_ID%"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -45,7 +45,7 @@ REACT_APP_OPTIMIZE_ID=GTM-abc
 #### A/B Test
 If the experience is a **A/B testing** you can use the lib like the following:
 
-```
+```jsx
 import React from 'react';
 import { Experiment, Variant } from "react-optimize";
 
@@ -73,54 +73,56 @@ If the experience is a **multivariate testing** to test variants with two or mor
 
 ![google optimize multivariate test](./google-optimize-test.png)
 
-```
+```jsx
 import React from 'react';
 import { Experiment, Variant } from "react-optimize";
 
 class App extends React.Component {
   render() {
     return(
-      <Experiment 
-        id="<experiment-id>"
-        asMtvExperiment
-        indexSectionPosition="0"
-      >
-        <Variant id="0">
-          Original
-        </Variant>
-        <Variant id="1">
-          Variant 1
-        </Variant>
-      </Experiment>
+      <>
+        <Experiment 
+          id="<experiment-id>"
+          asMtvExperiment
+          indexSectionPosition="0"
+        >
+          <Variant id="0">
+            Original
+          </Variant>
+          <Variant id="1">
+            Variant 1
+          </Variant>
+        </Experiment>
 
-      <Experiment 
-        id="<experiment-id>"
-        asMtvExperiment
-        indexSectionPosition="1"
-      >
-        <Variant id="0">
-          Original
-        </Variant>
-        <Variant id="1">
-          Variant 1
-        </Variant>
-        <Variant id="2">
-          Variant 2
-        </Variant>
-      </Experiment>
+        <Experiment 
+          id="<experiment-id>"
+          asMtvExperiment
+          indexSectionPosition="1"
+        >
+          <Variant id="0">
+            Original
+          </Variant>
+          <Variant id="1">
+            Variant 1
+          </Variant>
+          <Variant id="2">
+            Variant 2
+          </Variant>
+        </Experiment>
 
-      <Experiment 
-        id="<experiment-id>"
-        asMtvExperiment
-        indexSectionPosition="2"
-      >
-        <Variant id="0">
-          Original
-        </Variant>
-        <Variant id="1">
-          Variant 1
-        </Variant>
-      </Experiment>
+        <Experiment 
+          id="<experiment-id>"
+          asMtvExperiment
+          indexSectionPosition="2"
+        >
+          <Variant id="0">
+            Original
+          </Variant>
+          <Variant id="1">
+            Variant 1
+          </Variant>
+        </Experiment>
+      </>
     )
   }
 }


### PR DESCRIPTION
Examples in readme did not have Fragments and `jsx` annotation on code blocks